### PR TITLE
Add support for OpenWeatherMap API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,18 @@ npm i vue-weather-widget
 yarn add vue-weather-widget
 ```
 
+## API Keys
+
+This component works with both the DarkSky API, and the OpenWeatherMap API. Since it is no longer 
+possible to create a DarkSky API key, it is recommended to use OpenWeatherMap. https://openweathermap.org/appid
+
 ## Usage
 
 ### Vue
 
 ```html
 <template>
-  <vue-weather api-key="<your-dark-sky-api-key>" units="uk" />
+  <vue-weather api-key="<your-api-key>" units="uk" />
 </template>
 
 <script>
@@ -69,7 +74,7 @@ yarn add vue-weather-widget
 <!-- Vue app -->
 <div id="app">
   <weather
-    api-key="<your-dark-sky-api-key>"
+    api-key="<your-api-key>"
     latitude="24.886436"
     longitude="91.880722"
     language="en"
@@ -90,19 +95,20 @@ yarn add vue-weather-widget
 
 ## Props
 
-| Props             | Type                | Default  | Description                                                                                                        |
-| ----------------- | :------------------ | :------: | ------------------------------------------------------------------------------------------------------------------ |
-| api-key           | String (_required_) |    -     | Your Dark Sky API key                                                                                              |
-| address           | String              | current  | An address of a location (By default, it will be use user's IP to find current location)                           |
-| latitude          | String              | current  | The latitude of a location (By default, it will be use user's IP to find current location)                         |
-| longitude         | String              | current  | The longitude of a location (By default, it will be use user's IP to find current location)                        |
-| language          | String              |  `"en"`  | A list of supported languages are given below.                                                                     |
-| units             | String              |  `"us"`  | A list of supported units are given below.                                                                         |
-| hide-header       | Boolean             | `false`  | Whether to show or hide the title bar.                                                                             |
-| update-interval   | Number              |  `null`  | Interval in _milliseconds_ to update weather data periodically. Seting it to `0` or `null` to disables autoupdate. |
-| disable-animation | Boolean             | `false`  | Use static icons when enabled.                                                                                     |
-| bar-color         | String              | `"#444"` | Color of the Temparature bar.                                                                                      |
-| text-color        | String              | `"#333"` | Color of the text.                                                                                                 |
+| Props                | Type                | Default  | Description                                                                                                        |
+|----------------------|---------------------|----------|--------------------------------------------------------------------------------------------------------------------|
+| use-open-weather-map | Boolean             | `true`   | Use OpenWeatherMap API instead of Dark Sky API                                                                     |
+| api-key              | String (_required_) | -        | Your OpenWeatherMap or Dark Sky API key                                                                            |
+| address              | String              | current  | An address of a location (By default, it will be use user's IP to find current location)                           |
+| latitude             | String              | current  | The latitude of a location (By default, it will be use user's IP to find current location)                         |
+| longitude            | String              | current  | The longitude of a location (By default, it will be use user's IP to find current location)                        |
+| language             | String              | `"en"`   | A list of supported languages are given below.                                                                     |
+| units                | String              | `"us"`   | A list of supported units are given below.                                                                         |
+| hide-header          | Boolean             | `false`  | Whether to show or hide the title bar.                                                                             |
+| update-interval      | Number              | `null`   | Interval in _milliseconds_ to update weather data periodically. Seting it to `0` or `null` to disables autoupdate. |
+| disable-animation    | Boolean             | `false`  | Use static icons when enabled.                                                                                     |
+| bar-color            | String              | `"#444"` | Color of the Temparature bar.                                                                                      |
+| text-color           | String              | `"#333"` | Color of the text.                                                                                                 |
 
 ## Slots
 

--- a/examples/static/dist/css/vue-weather-widget.css
+++ b/examples/static/dist/css/vue-weather-widget.css
@@ -14,6 +14,7 @@
 .vww__title {
   font-size: 18px;
   font-weight: bold;
+  text-transform: capitalize;
 }
 
 .vww__content {

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -29,7 +29,8 @@
 <body>
 
   <div id="app">
-    <weather api-key="e20753dfcaae902ab091fbb4925d432a" units="uk"></weather>
+    <!-- <weather api-key="e20753dfcaae902ab091fbb4925d432a" units="uk" :use-open-weather-map="false"></weather> -->
+    <weather api-key="45aee2ef715cfa91ed7957e8cfd37a70"></weather>
   </div>
 
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -30,7 +30,7 @@
 
   <div id="app">
     <!-- <weather api-key="e20753dfcaae902ab091fbb4925d432a" units="uk" :use-open-weather-map="false"></weather> -->
-    <weather api-key="45aee2ef715cfa91ed7957e8cfd37a70"></weather>
+    <weather api-key="45aee2ef715cfa91ed7957e8cfd37a70" units="uk"></weather>
   </div>
 
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>

--- a/src/script.js
+++ b/src/script.js
@@ -9,7 +9,13 @@ export default {
   },
 
   props: {
-    // Your Dark Sky secret key
+    // use OpenWeatherMap vs DarkSky API?
+    useOpenWeatherMap: {
+      type: Boolean,
+      default: true
+    },
+
+    // Your Dark Sky / OpenWeatherMap secret key
     apiKey: {
       type: String,
       required: true,
@@ -126,7 +132,7 @@ export default {
       let globalMinTemp = Infinity;
 
       const time = new Date().getTime() / 1e3;
-      const daily = this.weather.daily.data;
+      const daily = this.weather.daily.data
       for (let i = 0; i < daily.length; i++) {
         const day = daily[i];
         if (day.temperatureMax > globalMaxTemp) {
@@ -161,14 +167,17 @@ export default {
 
   methods: {
     loadWeather() {
-      return Utils.fetchWeather({
+      const args = {
         apiKey: this.apiKey,
         lat: this.location.lat,
         lng: this.location.lng,
         units: this.units,
         language: this.language,
-      }).then((data) => {
-        this.$set(this, "weather", data);
+      }
+      const method = this.useOpenWeatherMap ? Utils.fetchOWMWeather : Utils.fetchWeather
+      return method(args).then((data) => {
+        const weather = this.useOpenWeatherMap ? Utils.mapData(data) : data
+        this.$set(this, "weather", weather);
       });
     },
 

--- a/src/script.js
+++ b/src/script.js
@@ -132,7 +132,7 @@ export default {
       let globalMinTemp = Infinity;
 
       const time = new Date().getTime() / 1e3;
-      const daily = this.weather.daily.data
+      const daily = this.weather.daily.data;
       for (let i = 0; i < daily.length; i++) {
         const day = daily[i];
         if (day.temperatureMax > globalMaxTemp) {

--- a/src/script.js
+++ b/src/script.js
@@ -9,7 +9,7 @@ export default {
   },
 
   props: {
-    // use OpenWeatherMap vs DarkSky API?
+    // use OpenWeatherMap vs Dark Sky API?
     useOpenWeatherMap: {
       type: Boolean,
       default: true

--- a/src/script.js
+++ b/src/script.js
@@ -168,16 +168,17 @@ export default {
   methods: {
     loadWeather() {
       const { useOpenWeatherMap } = this
-      const method = useOpenWeatherMap ? Utils.fetchOWMWeather : Utils.fetchWeather
-      return method({
+      const fetchWeatherMethod = useOpenWeatherMap
+        ? Utils.fetchOWMWeather
+        : Utils.fetchWeather
+      return fetchWeatherMethod({
         apiKey: this.apiKey,
         lat: this.location.lat,
         lng: this.location.lng,
         units: this.units,
         language: this.language,
       }).then((data) => {
-        const weather = useOpenWeatherMap ? Utils.mapData(data) : data
-        this.$set(this, "weather", weather);
+        this.$set(this, "weather", data);
       });
     },
 

--- a/src/script.js
+++ b/src/script.js
@@ -167,16 +167,16 @@ export default {
 
   methods: {
     loadWeather() {
-      const args = {
+      const { useOpenWeatherMap } = this
+      const method = useOpenWeatherMap ? Utils.fetchOWMWeather : Utils.fetchWeather
+      return method({
         apiKey: this.apiKey,
         lat: this.location.lat,
         lng: this.location.lng,
         units: this.units,
         language: this.language,
-      }
-      const method = this.useOpenWeatherMap ? Utils.fetchOWMWeather : Utils.fetchWeather
-      return method(args).then((data) => {
-        const weather = this.useOpenWeatherMap ? Utils.mapData(data) : data
+      }).then((data) => {
+        const weather = useOpenWeatherMap ? Utils.mapData(data) : data
         this.$set(this, "weather", weather);
       });
     },

--- a/src/style.css
+++ b/src/style.css
@@ -14,6 +14,7 @@
 .vww__title {
   font-size: 18px;
   font-weight: bold;
+  text-transform: capitalize;
 }
 
 .vww__content {

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,7 +127,7 @@ export default {
       `&lon=${opts.lng}` +
       `&units=${units}` +
       `&lang=${opts.language}`
-    ).then((resp) => return this.mapData(resp.json()));
+    ).then((resp) => this.mapData(resp.json());
   },
 
   mapData(data = {}) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,24 @@ const IP_CACHE = "vww__cache_ip";
 const IP_LOCATION_CACHE = "vww__cache_ip_location";
 const GEOCODE_CACHE = "vww__cache_geocode";
 
+const ICON_MAPPINGS = {
+  'clear-day': ['01d'],
+  'clear-night': ['01n'],
+  'cloudy': ['03d', '03n'],
+  'fog': ['50d', '50n'],
+  'partly-cloudy-day': ['02d', '04d',],
+  'partly-cloudy-night': ['02n', '04n'],
+  'rain': ['09d', '09n', '10d', '10n', '11d', '11n'],
+  'sleet': ['13d', '13n'],
+  'snow': ['13d', '13n'],
+  'wind': ['50d', '50n']
+}
+
+const UNIT_MAPPINGS = {
+  'us': 'imperial',
+  'uk': 'metric'
+}
+
 export default {
   lookupIP() {
     let cache = localStorage[IP_CACHE] || "{}";
@@ -92,5 +110,64 @@ export default {
         `/${opts.lat},${opts.lng}` +
         `?units=${opts.units}&lang=${opts.language}`
     ).then((resp) => resp.json());
+  },
+
+  fetchOWMWeather(opts = {}) {
+    opts.units = opts.units || "us";
+    opts.language = opts.language || "en";
+    if (!opts.lat || !opts.lng) {
+      throw new Error("Geolocation is required");
+    }
+
+    const units = UNIT_MAPPINGS[opts.units]
+
+    return fetch(
+      `https://api.openweathermap.org/data/2.5/onecall?appid=${opts.apiKey}` +
+      `&lat=${opts.lat}` +
+      `&lon=${opts.lng}` +
+      `&units=${units}` +
+      `&lang=${opts.language}`
+    ).then((resp) => resp.json());
+  },
+
+  mapData(data = {}) {
+    const { current } = data
+    const { weather } = current
+    const [currentWeather] = weather
+    const { description, icon } = currentWeather
+    const iconName = this.mapIcon(icon)
+
+    return {
+      currently: Object.assign({}, current, {
+        icon: iconName,
+        temperature: current.temp,
+        summary: description,
+        windSpeed: current.wind_speed,
+        windBearing: current.wind_deg
+      }),
+      daily: {
+        data: data.daily.map(day => {
+          return {
+            temperatureMax: day.temp.max,
+            temperatureMin: day.temp.min,
+            time: day.dt,
+            icon: this.mapIcon(day.weather[0].icon),
+          }
+        })
+      },
+      hourly: {
+        data: data.hourly.map(hour => {
+          return {
+            temperature: hour.temp,
+          }
+        })
+      }
+    }
+  },
+
+  mapIcon(code) {
+    return Object.keys(ICON_MAPPINGS).find(key => {
+      return ICON_MAPPINGS[key].includes(code)
+    })
   },
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,7 +127,7 @@ export default {
       `&lon=${opts.lng}` +
       `&units=${units}` +
       `&lang=${opts.language}`
-    ).then((resp) => resp.json());
+    ).then((resp) => return this.mapData(resp.json()));
   },
 
   mapData(data = {}) {


### PR DESCRIPTION
#17

I left DarkSky API support intact, and opted to just transform the data from the OpenWeatherMap API to work with this component. 

Two questions for you:

1. Was there a technical reason you chose to use jsonp for the Dark Sky API call? CORS? Would it be better to do the same for OWM?
2. I added a boolean prop to determine which API to use and set the default to `true`. I guess I'd make the argument that since the Dark Sky API will eventually be shut down, OWM probably should be the default, on the other hand it is the only real breaking change here, I'm curious to hear your opinion on that. Maybe it's better to use `useDarkSkyApi` prop with default of `false`? Still a breaking change, but maybe that's more indicative of what is happening with the APIs?

(screenshots are in imperial units)

## Dark Sky:

<img width="843" alt="Screen Shot 2020-08-29 at 11 31 50 AM" src="https://user-images.githubusercontent.com/1086884/91640526-304b0d00-e9ec-11ea-8335-321ccece6110.png">

## OWM

<img width="842" alt="Screen Shot 2020-08-29 at 11 40 01 AM" src="https://user-images.githubusercontent.com/1086884/91640552-6ab4aa00-e9ec-11ea-86b4-50b014a63ed8.png">

